### PR TITLE
remove tzinfo-data gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,3 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -284,7 +284,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3 (~> 1.4)
-  tzinfo-data
   webmock
 
 BUNDLED WITH


### PR DESCRIPTION
## Why was this change made?

b/c we don't use this gem and it makes noisy warnings.

## Was the API documentation (openapi.json) updated?

n/a