### PR TITLE
ci rake task does rubocop before spec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ begin
   require 'rubocop/rake_task'
 
   desc 'Run linter and tests'
-  task ci: %i[spec rubocop]
+  task ci: %i[rubocop spec]
 rescue LoadError
   puts 'gems rspec and rubocop not available presumably b/c this is a production environment'
 end


### PR DESCRIPTION
## Why was this change made?

it was requested by @mjgiarlo in a comment on PR #38

## Was the API documentation (openapi.json) updated?

n/a