### PR TITLE
README: add ci and coverage badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[![CircleCI](https://circleci.com/gh/sul-dlss/repository-api.svg?style=svg)](https://circleci.com/gh/sul-dlss/repository-api)
+[![Maintainability](https://api.codeclimate.com/v1/badges/9b021ce4e6eb88230b53/maintainability)](https://codeclimate.com/github/sul-dlss/repository-api/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/9b021ce4e6eb88230b53/test_coverage)](https://codeclimate.com/github/sul-dlss/repository-api/test_coverage)
+
 # Repository API
 
 An HTTP API for the SDR.


### PR DESCRIPTION
## Why was this change made?

To add CI and coverage badges to the README

## Was the API documentation (openapi.yml) updated?

n/a
