### PR TITLE
Validate OpenAPI specification in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 references:
   default_docker_ruby_executor: &default_docker_ruby_executor
-    image: circleci/ruby:2.6.4-stretch
+    image: circleci/ruby:2.6.4-stretch-node
     environment:
       BUNDLER_VERSION: 2.1.4
       BUNDLE_JOBS: 3
@@ -69,11 +69,22 @@ jobs:
       - run:
           name: Bundle Install
           command: bundle check || bundle install
-
       - run:
           name: Lint using rubocop
           command: bundle exec rubocop
-
+      - run:
+          name: Validate API specification
+          command: |
+            sudo npm install -g openapi-enforcer-cli
+            result=$(openapi-enforcer validate openapi.yml)
+            [[ $result =~ "Document is valid" ]] && {
+            echo "API specification is valid OAS (but may have warnings, see below)"
+            echo $result
+            exit 0
+            } || {
+            echo $result
+            exit 1
+            }
       - run:
           name: Wait for database
           command: dockerize -wait tcp://localhost:5432 -timeout 1m

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![CircleCI](https://circleci.com/gh/sul-dlss/repository-api.svg?style=svg)](https://circleci.com/gh/sul-dlss/repository-api)
 [![Maintainability](https://api.codeclimate.com/v1/badges/9b021ce4e6eb88230b53/maintainability)](https://codeclimate.com/github/sul-dlss/repository-api/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/9b021ce4e6eb88230b53/test_coverage)](https://codeclimate.com/github/sul-dlss/repository-api/test_coverage)
+[![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/repository-api/master/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/repository-api/master/openapi.yml)
 
 # Repository API
 


### PR DESCRIPTION
Fixes #41

## Why was this change made?

When running CI, after linting the code, validate the API specification. Ensure it is valid per the OpenAPI Specification/OAS (semantic check).

Note that by validating OAS, we are also ensuring it is valid YAML (syntactic check). We do not need a separate tool or check for this.

This step is important since the API application uses the committee gem to parse the spec and enforce specified constraints, e.g., controller parameters, and the committee gem does not provide the most useful feedback when the spec is not valid.

Also, include the OpenAPI Spec validator badge in the README.

## Was the documentation (README.md, openapi.yml) updated?

Yes.