### PR TITLE
Add a dockerfile for the repository-api

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.dockerignore
+.byebug_history
+log/*
+tmp/*
+postgres-data/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+
+# This Dockerfile is optimized for running in development. That means it trades
+# build speed for size. If we were using this for production, we might instead
+# optimize for a smaller size at the cost of a slower build.
+FROM ruby:2.6.4-alpine
+
+# postgresql-client is required for invoke.sh
+RUN apk add --update --no-cache  \
+  build-base \
+  postgresql-dev \
+  postgresql-client \
+  tzdata \
+  libxml2-dev \
+  libxslt-dev \
+  yarn
+
+RUN mkdir /app
+WORKDIR /app
+
+RUN gem update --system && \
+  gem install bundler && \
+  bundle config build.nokogiri --use-system-libraries
+
+COPY Gemfile Gemfile.lock ./
+
+RUN bundle config set without 'production'
+RUN bundle install
+
+COPY . .
+
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb", "config.ru"]

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.1'
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3', '~> 1.4'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.7'
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,35 @@ An HTTP API for the SDR.
 
 There is a [OAS 3.0 spec](http://spec.openapis.org/oas/v3.0.2) that documents the API in [openapi.yml].  If you clone this repo, you can view this by opening [docs/index.html].
 
+## Local Development
+
+### Start dependencies
+
+#### Database
+
+```
+docker-compose up -d db
+```
+
+### Build the api container
+
+```
+docker-compose build app
+```
+
+### Setup the local database
+
+```
+docker-compose run --rm app bundle exec rake db:create
+docker-compose run --rm app bundle exec rake db:migrate
+```
+
+### Start the app
+
+```
+docker-compose up -d app
+```
+
 ## Create a user
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,22 @@
 version: '3.6'
 
 services:
+  app:
+    build: .
+    volumes:
+      - ./:/app
+    working_dir: /app
+    depends_on:
+      - db
+    ports:
+      - 3000:3000
+    environment:
+      DATABASE_NAME: sdr
+      DATABASE_USERNAME: postgres
+      DATABASE_PASSWORD: sekret
+      DATABASE_HOSTNAME: db
+      DATABASE_PORT: 5432
+      RAILS_LOG_TO_STDOUT: 'true'
   db:
     image: postgres:11
     ports:


### PR DESCRIPTION
## Why was this change made?

Fixes #2 

Also removes the unused sqllite gem.

## Was the API documentation (openapi.yml) updated?

README update with docker based instructions