### PR TITLE
Update circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 version: 2.1
-
+executors:
+  docker-publisher:
+    environment:
+      IMAGE_NAME: suldlss/sdr-api
+    docker:
+      - image: circleci/buildpack-deps:stretch
+    
 references:
   default_docker_ruby_executor: &default_docker_ruby_executor
     image: circleci/ruby:2.6.4-stretch-node
@@ -105,6 +111,55 @@ jobs:
           command: ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
       # - store_test_results:
       #     path: test_results
+  build-image:
+    executor: docker-publisher
+    steps:
+    - checkout
+    - setup_remote_docker
+    - run:
+        name: Build Docker image
+        command: |
+          docker build -t $IMAGE_NAME:latest .
+    - run:
+        name: Archive Docker image
+        command: |
+          docker save -o app_image.tar $IMAGE_NAME
+    - persist_to_workspace:
+        root: .
+        paths:
+        - ./app_image.tar
+  publish-latest:
+    executor: docker-publisher
+    steps:
+    - attach_workspace:
+        at: /tmp/workspace
+    - setup_remote_docker
+    - run:
+        name: Load archived Docker image
+        command: |
+          docker load -i /tmp/workspace/app_image.tar
+    - run:
+        name: Publish Docker Image to Docker Hub
+        command: |
+          echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+          docker push $IMAGE_NAME:latest
+  publish-tag:
+    executor: docker-publisher
+    steps:
+    - attach_workspace:
+        at: /tmp/workspace
+    - setup_remote_docker
+    - run:
+        name: Load archived Docker image
+        command: |
+          docker load -i /tmp/workspace/app_image.tar
+    - run:
+        name: Publish Docker Image to Docker Hub
+        command: |
+          echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+          docker tag $IMAGE_NAME:latest $IMAGE_NAME:$CIRCLE_TAG
+          docker push $IMAGE_NAME:$CIRCLE_TAG
+
 workflows:
   version: 2
   build_and_test:
@@ -113,3 +168,31 @@ workflows:
       - test:
           requires:
             - build
+  build:
+    jobs:
+    - build-image:
+        filters:
+          branches:
+            only: master
+    - publish-latest:
+        requires:
+        - build-image
+        filters:
+          branches:
+            only: master
+  build-tags:
+    jobs:
+    - build-image:
+        filters:
+          tags:
+            only: /^[0-9]+\.[0-9]+\.[0-9]+/
+          branches:
+            ignore: /.*/
+    - publish-tag:
+        requires:
+        - build-image
+        filters:
+          tags:
+            only: /^[0-9]+\.[0-9]+\.[0-9]+/
+          branches:
+            ignore: /.*/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/9b021ce4e6eb88230b53/maintainability)](https://codeclimate.com/github/sul-dlss/repository-api/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/9b021ce4e6eb88230b53/test_coverage)](https://codeclimate.com/github/sul-dlss/repository-api/test_coverage)
 [![OpenAPI Validator](http://validator.swagger.io/validator?url=https://raw.githubusercontent.com/sul-dlss/repository-api/master/openapi.yml)](http://validator.swagger.io/validator/debug?url=https://raw.githubusercontent.com/sul-dlss/repository-api/master/openapi.yml)
+[![Docker image](https://images.microbadger.com/badges/image/suldlss/sdr-api.svg)](https://microbadger.com/images/suldlss/sdr-api "Get your own image badge on microbadger.com")
 
 # Repository API
 


### PR DESCRIPTION
## Why was this change made?

Updates circleci to publish the latest docker image on merge to master and a tagged version (if we user releases).

## Was the documentation (README.md, openapi.yml) updated?

Docker layers badge is added to the README
