### PR TITLE
Enable Capistrano Passenger plugin

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -32,7 +32,7 @@ install_plugin Capistrano::SCM::Git
 # require 'capistrano/rbenv'
 # require 'capistrano/chruby'
 require 'capistrano/bundler'
-# require 'capistrano/passenger' # Uncomment when passenger is installed
+require 'capistrano/passenger'
 require 'capistrano/honeybadger'
 # require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,7 +311,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.2)
     sshkit (1.20.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -356,7 +355,6 @@ DEPENDENCIES
   simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3 (~> 1.4)
   webmock
 
 BUNDLED WITH


### PR DESCRIPTION
## Why was this change made?

Now that Passenger is installed on stage, enable Capistrano to restart the passenger instance.

Also, push up a new Gemfile.lock since `sqlite` was removed earlier.

## Was the documentation (README.md, openapi.yml) updated?

no.